### PR TITLE
Fix core peerDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 ### Removed
 
+## [1.3.1] - 2019-01-03
+### Fixed
+- Change @mocks-server/core peerDependency to ^1.3.0, which is the first one with behavior id property.
+
 ## [1.3.0] - 2019-01-03
 ### Added
 - Add property id to behaviors model.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/plugin-admin-api",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mocks-server/plugin-admin-api",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Plugin for Mocks Server. Provides a REST API for administrating settings, fixtures and behaviors",
   "keywords": [
     "mocks-server-plugin",
@@ -32,7 +32,7 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "peerDependencies": {
-    "@mocks-server/core": "^1.1.0"
+    "@mocks-server/core": "^1.3.0"
   },
   "dependencies": {
     "@mocks-server/admin-api-paths": "1.0.2",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=mocks-server
 sonar.projectKey=mocks-server-plugin-admin-api
-sonar.projectVersion=1.3.0
+sonar.projectVersion=1.3.1
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
### Fixed
- Change @mocks-server/core peerDependency to ^1.3.0, which is the first one with behavior id property.